### PR TITLE
Update to allow Drupal user account autocreation.

### DIFF
--- a/onelogin_saml/functions.php
+++ b/onelogin_saml/functions.php
@@ -88,6 +88,7 @@ function onelogin_saml_metadata() {
 function onelogin_saml_auth($auth) {
   $username = '';
   $email = '';
+  $autocreate = variable_get('saml_options_autocreate', FALSE);
 
   // Get the NameId.
   $nameId = $auth->getNameId();


### PR DESCRIPTION
The module was not creating users even with the setting enabled. Noticed that the $autocreate variable was not set so this PR creates the variable in the onelogin_saml_auth function and sets it to the value of the autocreate setting. 