### PR TITLE
Retain user roles after login and pass on destination parameter 

### DIFF
--- a/onelogin_saml/functions.php
+++ b/onelogin_saml/functions.php
@@ -206,7 +206,8 @@ function onelogin_saml_auth($auth) {
   if ($result && $user = user_load(key($result['user']))) {
     $GLOBALS['user'] = $user;
     $form_state['uid'] = $user->uid;
-
+    //If a user has previously logged in, we pull the roles it already has
+    $roles = $user->roles;
     if (!empty($roles)) {
       try {
         $fields = array(

--- a/onelogin_saml/functions.php
+++ b/onelogin_saml/functions.php
@@ -52,7 +52,13 @@ function onelogin_saml_acs() {
     drupal_set_message("No SAML Response found.", 'error', FALSE);
     drupal_goto('');
   }
-
+  /*When a user logins using OneLogin and the URL has a destination parameter in it, 
+  * we redirect them to the page after logging in
+  * Works because we append destination parameter to OneLogin SAML url 
+  */
+  if(isset($_POST['RelayState'])){
+    drupal_goto($_POST['RelayState']);
+  }
   drupal_goto('user/' . $user->uid);
 }
 

--- a/onelogin_saml/onelogin_saml.module
+++ b/onelogin_saml/onelogin_saml.module
@@ -148,8 +148,9 @@ function _onelogin_saml_user_login_form_alter(&$form, &$form_state) {
   if ($showSamlLink) {
     // Add a "Log in using SAML" link to the user-login form.
     $items = array();
+    //Pass on a destination parameter to OneLogin. The OneLogin ldp will pass it back to us using RelayState
     $items[] = array(
-      'data' => l(t('Log in using SAML'), url('onelogin_saml/sso', array('absolute' => true)), array('external' => TRUE)), 
+      'data' => l(t('Log in using SAML'), url('onelogin_saml/sso', array('absolute' => true)), array('external' => TRUE),array('query'=>array('destination'=>drupal_get_destination()))), 
       'class' => array('saml-link'),
     );
 


### PR DESCRIPTION
This will allow the users logging in using OneLogin to retain their roles on next login (e.g. a user logins using OneLogin where he will get a default assigned role, an admin can assign additional roles to that users from backend and we never check for existing roles). By adding this line, we pull the existing roles a user may have.

The check for RelayState and passing destination parameter in "Login using SAML" link is related. When we pass a destination parameter, the response from OneLogin will contain the destination in the RelayState parameter so we can redirect the users to that page after logging in using SAML.